### PR TITLE
enumerate only consumers existing in deployment table

### DIFF
--- a/src/Journalist.EventStore/Streams/ConsumersService.cs
+++ b/src/Journalist.EventStore/Streams/ConsumersService.cs
@@ -2,44 +2,47 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Journalist.EventStore.Journal;
+using Journalist.Options;
 
 namespace Journalist.EventStore.Streams
 {
-	public class ConsumersService : IConsumersService
-	{
-		private readonly IEventStreamConsumers m_eventStreamConsumers;
-		private readonly IEventJournal m_eventJournal;
+    public class ConsumersService : IConsumersService
+    {
+        private readonly IEventStreamConsumers m_eventStreamConsumers;
+        private readonly IEventJournal m_eventJournal;
 
-		public ConsumersService(IEventStreamConsumers eventStreamConsumers, IEventJournal eventJournal)
-		{
-			Require.NotNull(eventStreamConsumers, nameof(eventStreamConsumers));
-			Require.NotNull(eventJournal, nameof(eventJournal));
+        public ConsumersService(IEventStreamConsumers eventStreamConsumers, IEventJournal eventJournal)
+        {
+            Require.NotNull(eventStreamConsumers, nameof(eventStreamConsumers));
+            Require.NotNull(eventJournal, nameof(eventJournal));
 
-			m_eventStreamConsumers = eventStreamConsumers;
-			m_eventJournal = eventJournal;
-		}
+            m_eventStreamConsumers = eventStreamConsumers;
+            m_eventJournal = eventJournal;
+        }
 
-		public async Task<IEnumerable<ConsumerDescription>> EnumerateConsumersAsync(string streamName)
-		{
-			Require.NotEmpty(streamName, nameof(streamName));
+        public async Task<IEnumerable<ConsumerDescription>> EnumerateConsumersAsync(string streamName)
+        {
+            Require.NotEmpty(streamName, nameof(streamName));
 
-			var streamReaderDescriptions = await m_eventJournal.GetStreamReadersDescriptionsAsync(streamName);
+            var streamReaderDescriptions = await m_eventJournal.GetStreamReadersDescriptionsAsync(streamName);
 
-			var descriptionsWithConsumerNames = streamReaderDescriptions.Select(
-				streamReaderDescription => new
-				{
-					streamReaderDescription,
-					consumerNameTask = m_eventStreamConsumers.GetNameAsync(streamReaderDescription.StreamReaderId)
-				});
+            var descriptionsWithConsumerNames = streamReaderDescriptions.Select(
+                streamReaderDescription => new
+                {
+                    streamReaderDescription,
+                    consumerNameTask = m_eventStreamConsumers.TryGetNameAsync(streamReaderDescription.StreamReaderId)
+                });
 
-			await Task.WhenAll(descriptionsWithConsumerNames.Select(description => description.consumerNameTask));
-			
-			var consumerDescriptions = descriptionsWithConsumerNames.Select(description => new ConsumerDescription(
-				description.streamReaderDescription.StreamVersion,
-				description.consumerNameTask.Result,
-				description.streamReaderDescription.StreamReaderId));
+            await Task.WhenAll(descriptionsWithConsumerNames.Select(description => description.consumerNameTask));
 
-			return consumerDescriptions;
-		}
-	}
+            var consumerDescriptions = descriptionsWithConsumerNames
+                .Where(description => description.consumerNameTask.Result.IsSome)
+                .Select(description => new ConsumerDescription(
+                    description.streamReaderDescription.StreamVersion,
+                    description.consumerNameTask.Result.GetOrDefault(default(string)),
+                    description.streamReaderDescription.StreamReaderId));
+
+            return consumerDescriptions;
+        }
+    }
 }

--- a/src/Journalist.EventStore/Streams/IEventStreamConsumers.cs
+++ b/src/Journalist.EventStore/Streams/IEventStreamConsumers.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Journalist.EventStore.Journal;
+using Journalist.Options;
 
 namespace Journalist.EventStore.Streams
 {
@@ -7,6 +8,6 @@ namespace Journalist.EventStore.Streams
     {
         Task<EventStreamReaderId> RegisterAsync(string consumerName);
 
-	    Task<string> GetNameAsync(EventStreamReaderId eventStreamReaderId);
+	    Task<Option<string>> TryGetNameAsync(EventStreamReaderId eventStreamReaderId);
     }
 }


### PR DESCRIPTION
there was a bug in consumers creation process that caused consumers creation on each EventStore deployment. some journals has left with missing in deployment table RDR-records. attempt to enumerate consumers for this journals caused NRE. this fix reworks enumerate method to return only consumers existing in deployment table